### PR TITLE
chore: remove zabbix_agent_nonroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,30 @@ ansible role to install zabbix agent on CentOS
 
 https://galaxy.ansible.com/suzuki-shunsuke/zabbix-agent-centos/
 
-Requirements
-------------
+## Requirements
 
 Nothing.
 
-Role Variables
---------------
+## Role Variables
 
-* zabbix_full_version: zabbix version. This is required.
+name | required | description
+--- | --- | ---
+zabbix_full_version | yes | zabbix version
 
-Dependencies
-------------
+## Dependencies
 
 Nothing.
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: servers
   roles:
   - role: suzuki-shunsuke.zabbix-agent-centos
     zabbix_full_version: 3.2.4-2
+    become: yes
 ```
 
-License
--------
+## License
 
-MIT
+[MIT](LICENSE)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,9 +5,7 @@
   yum:
     name: http://repo.zabbix.com/zabbix/{{zabbix_full_version[:3]}}/rhel/{{ansible_distribution_major_version}}/x86_64/zabbix-agent-{{zabbix_full_version}}.el{{ansible_distribution_major_version}}.x86_64.rpm
     update_cache: yes
-  become: "{{zabbix_agent_nonroot}}"
 - name: Install zabbix agent
   yum:
     name: zabbix-agent
     update_cache: yes
-  become: "{{zabbix_agent_nonroot}}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,3 +3,4 @@
   roles:
   - role: ansible-zabbix-agent-centos
     zabbix_full_version: 3.2.4-2
+    become: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-# vars file for zabbix-agent-centos
-zabbix_agent_nonroot: "{{ (ansible_env.HOME == '/root') | ternary('no', 'yes') }}"


### PR DESCRIPTION
BREAKING CHANGE: `become: yes` is required unless the remote user is root